### PR TITLE
Turn on channel 2 on timer 2

### DIFF
--- a/Sw_Components/01_App/HwCfg/port_cfg.c
+++ b/Sw_Components/01_App/HwCfg/port_cfg.c
@@ -19,8 +19,8 @@
 */
 const uint32_t portA_mode = 
 (
-    GPIO_0_ALT_FUN_MODE|
-    GPIO_1_INPUT_MODE  |
+    GPIO_0_ALT_FUN_MODE| /* TIM2 pin - motor 1*/
+    GPIO_1_ALT_FUN_MODE| /* TIM2 pin - motor 2*/
     GPIO_2_INPUT_MODE  |
     GPIO_3_INPUT_MODE  |
     GPIO_4_OUTPUT_MODE | /* Debug DIO 1 */
@@ -38,6 +38,7 @@ const uint32_t portA_mode =
 );
 const uint32_t portB_mode =
 (
+    GPIO_0_INPUT_MODE   |
     GPIO_1_INPUT_MODE   |
     GPIO_2_INPUT_MODE   |
     GPIO_3_INPUT_MODE   |
@@ -58,7 +59,7 @@ const uint32_t portB_mode =
 const uint32_t portA_afrl = 
 (
     GPIO_0_ALT_FUN_1| /* TIM2 pin */
-    GPIO_1_ALT_FUN_0|
+    GPIO_1_ALT_FUN_1| /* TIM2 pin */
     GPIO_2_ALT_FUN_0|
     GPIO_3_ALT_FUN_0|
     GPIO_4_ALT_FUN_0|

--- a/Sw_Components/04_Drv/pwm/pwm.c
+++ b/Sw_Components/04_Drv/pwm/pwm.c
@@ -63,8 +63,8 @@ void PwmInit(const Pwm_Cfg_T *config)
 
     timer_instance->PSC = config->prescaler_val;                    /* Set prescaler value */
     timer_instance->ARR = FIRST_PERIOD;                             /* Must be set before enabling automatic preload to avoid waiting for first overflow*/
-    timer_instance->CCMR1 |= (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2); /*Pwm mode 1*/
-    timer_instance->CCMR1 |= TIM_CCMR1_OC1PE;                       /*Enable the Preload register*/
+    timer_instance->CCMR1 |= (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2); /*Pwm mode 1 for channel 1 and 2*/
+    timer_instance->CCMR1 |= (TIM_CCMR1_OC1PE | TIM_CCMR1_OC2PE);   /*Enable the Preload register for channel 1 and 2 */
     timer_instance->CR1 |= TIM_CR1_ARPE;                            /*Enable the auto-reload Preload register */
     timer_instance->CCER |= config->chan_sel;                       /* Set channels as output */
 


### PR DESCRIPTION
- add setting the pwm 'Mode 1' and enabling the 'preload register' for channel 2
- set alternate function for GPIO connected to channel 2